### PR TITLE
Add Pgpool min and max level support

### DIFF
--- a/pgnumbra/config.py
+++ b/pgnumbra/config.py
@@ -62,6 +62,12 @@ def parse_args():
     parser.add_argument('-t', '--threads', type=int, default=4,
                         help="Number of parallel threads to check accounts with shadowcheck.py.")
 
+    parser.add_argument('-pgpmin', '--pgpool-min-level', type=int, default=1,
+                        help="shadowcheck.py: Minimum level of account to request from pgpool")
+
+    parser.add_argument('-pgpmax', '--pgpool-max-level', type=int, default=40,
+                        help="shadowcheck.py: Maximum level of account to request from pgpool")
+
     parser.add_argument('-pgpu', '--pgpool-url',
                         help='Address of PGPool to load accounts from and/or update their details.')
 

--- a/pgnumbra/config.py
+++ b/pgnumbra/config.py
@@ -63,10 +63,10 @@ def parse_args():
                         help="Number of parallel threads to check accounts with shadowcheck.py.")
 
     parser.add_argument('-pgpmin', '--pgpool-min-level', type=int, default=1,
-                        help="shadowcheck.py: Minimum level of account to request from pgpool")
+                        help="Minimum/Maximum trainer level to request from PGPool")
 
     parser.add_argument('-pgpmax', '--pgpool-max-level', type=int, default=40,
-                        help="shadowcheck.py: Maximum level of account to request from pgpool")
+                        help="Minimum/Maximum trainer level to request from PGPool")
 
     parser.add_argument('-pgpu', '--pgpool-url',
                         help='Address of PGPool to load accounts from and/or update their details.')

--- a/pgnumbra/config.py
+++ b/pgnumbra/config.py
@@ -63,10 +63,10 @@ def parse_args():
                         help="Number of parallel threads to check accounts with shadowcheck.py.")
 
     parser.add_argument('-pgpmin', '--pgpool-min-level', type=int, default=1,
-                        help="Minimum/Maximum trainer level to request from PGPool")
+                        help="Minimum trainer level to request from PGPool")
 
     parser.add_argument('-pgpmax', '--pgpool-max-level', type=int, default=40,
-                        help="Minimum/Maximum trainer level to request from PGPool")
+                        help="Maximum trainer level to request from PGPool")
 
     parser.add_argument('-pgpu', '--pgpool-url',
                         help='Address of PGPool to load accounts from and/or update their details.')

--- a/pgnumbra/utils.py
+++ b/pgnumbra/utils.py
@@ -70,6 +70,8 @@ def pgpool_load_accounts(num):
     request = {
         'system_id': get_pgpool_system_id(),
         'count': num,
+        'min_level': cfg_get('pgpool_min_level'),
+        'max_level': cfg_get('pgpool_max_level'),
         'banned_or_new': True
     }
 


### PR DESCRIPTION
Add support for existing pgpool min_level and max_level support within PGScout.  It is currently random as to what level accounts you will get will requesting from pgpool

Example usage:  Use --pgpool_min_level 30 to only check accounts that are at least level 30.  